### PR TITLE
fix: #8 - The response.header type is 'http.client.HTTPMessage', not …

### DIFF
--- a/HackRequests/HackRequests.py
+++ b/HackRequests/HackRequests.py
@@ -368,7 +368,7 @@ class response(object):
             self.cookies = {}
 
         self.headers = _header_dict
-        self.header = self.rep.msg  # response header
+        self.header = str(self.rep.msg)  # response header
         self.log = log
         charset = self.rep.msg.get('content-type', 'utf-8')
         try:


### PR DESCRIPTION
The response.header type is 'http.client.HTTPMessage', not a string. 