### PR TITLE
为http() 增加了 params 参数，支持以 dict 形式传入query string

### DIFF
--- a/HackRequests/HackRequests.py
+++ b/HackRequests/HackRequests.py
@@ -248,7 +248,7 @@ class hackRequests(object):
         log["response"] = "HTTP/%.1f %d %s" % (
             rep.version * 0.1, rep.status,
             rep.reason) + '\r\n' + str(rep.msg)
-        if port == 80 or port == 
+        if port == 80 or port == 443:
             _url = "{scheme}://{host}{path}".format(scheme=scheme, host=host, path=path)
         else:
             _url = "{scheme}://{host}{path}".format(scheme=scheme, host=host + ":" + port, path=path)

--- a/HackRequests/HackRequests.py
+++ b/HackRequests/HackRequests.py
@@ -15,8 +15,6 @@ import zlib
 from http import client
 from urllib import parse
 
-from pytest import param
-
 
 class HackError(Exception):
     def __init__(self, content):
@@ -157,6 +155,7 @@ class hackRequests(object):
         proxy = kwargs.get("proxy", None)
         real_host = kwargs.get("real_host", None)
         ssl = kwargs.get("ssl", False)
+        location = kwargs.get("location", True)
 
         scheme = 'http'
         port = 80
@@ -253,6 +252,13 @@ class hackRequests(object):
             _url = "{scheme}://{host}{path}".format(scheme=scheme, host=host, path=path)
         else:
             _url = "{scheme}://{host}{path}".format(scheme=scheme, host=host + ":" + port, path=path)
+        
+        redirect = rep.msg.get('location', None)  # handle 301/302
+        if redirect and location:
+            if not redirect.startswith('http'):
+                redirect = parse.urljoin(_url, redirect)
+            return self.http(redirect, post=None, method=method, headers=headers, location=True, locationcount=1)
+
         return response(rep, _url, log, )
 
     def http(self, url, **kwargs):
@@ -287,7 +293,6 @@ class hackRequests(object):
             del headers["Content-Length"]
 
         urlinfo = scheme, host, port, path = self._get_urlinfo(url, params,real_host)
-
         log = {}
         try:
             conn = self.httpcon.get_con(urlinfo, proxy=proxy)
@@ -308,15 +313,18 @@ class hackRequests(object):
                     post = parse.urlencode(post)
                 except:
                     pass
-            else:
-                raise Exception("post must be str or dict")
-            tmp_headers["Content-Type"] = kwargs.get(
-                "Content-type", "application/x-www-form-urlencoded")
-            tmp_headers["Accept"] = tmp_headers.get("Accept", "*/*")
-        tmp_headers['Accept-Encoding'] = tmp_headers.get("Accept-Encoding", "gzip, deflate")
-        tmp_headers['Connection'] = 'close'
-        tmp_headers['User-Agent'] = tmp_headers['User-Agent'] if tmp_headers.get(
-            'User-Agent') else 'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.71 Safari/537.36'
+            if "Content-Type" not in headers:
+                tmp_headers["Content-Type"] = kwargs.get(
+                    "Content-type", "application/json")
+            if 'Accept' not in headers:
+                tmp_headers["Accept"] = tmp_headers.get("Accept", "*/*")
+        if 'Accept-Encoding' not in headers:
+            tmp_headers['Accept-Encoding'] = tmp_headers.get("Accept-Encoding", "gzip, deflate")
+        if 'Connection' not in headers:
+            tmp_headers['Connection'] = 'close'
+        if 'User-Agent' not in headers:
+            tmp_headers['User-Agent'] = tmp_headers['User-Agent'] if tmp_headers.get(
+                'User-Agent') else 'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.71 Safari/537.36'
 
         try:
             conn.request(method, path, post, tmp_headers)
@@ -381,7 +389,7 @@ class response(object):
             self.cookies = {}
 
         self.headers = _header_dict
-        self.header = self.rep.msg  # response header
+        self.header = str(self.rep.msg)  # response header
         self.log = log
         charset = self.rep.msg.get('content-type', 'utf-8')
         try:

--- a/HackRequests/HackRequests.py
+++ b/HackRequests/HackRequests.py
@@ -15,6 +15,8 @@ import zlib
 from http import client
 from urllib import parse
 
+from pytest import param
+
 
 class HackError(Exception):
     def __init__(self, content):
@@ -155,7 +157,6 @@ class hackRequests(object):
         proxy = kwargs.get("proxy", None)
         real_host = kwargs.get("real_host", None)
         ssl = kwargs.get("ssl", False)
-        location = kwargs.get("location", True)
 
         scheme = 'http'
         port = 80
@@ -252,13 +253,6 @@ class hackRequests(object):
             _url = "{scheme}://{host}{path}".format(scheme=scheme, host=host, path=path)
         else:
             _url = "{scheme}://{host}{path}".format(scheme=scheme, host=host + ":" + port, path=path)
-        
-        redirect = rep.msg.get('location', None)  # handle 301/302
-        if redirect and location:
-            if not redirect.startswith('http'):
-                redirect = parse.urljoin(_url, redirect)
-            return self.http(redirect, post=None, method=method, headers=headers, location=True, locationcount=1)
-
         return response(rep, _url, log, )
 
     def http(self, url, **kwargs):
@@ -293,6 +287,7 @@ class hackRequests(object):
             del headers["Content-Length"]
 
         urlinfo = scheme, host, port, path = self._get_urlinfo(url, params,real_host)
+
         log = {}
         try:
             conn = self.httpcon.get_con(urlinfo, proxy=proxy)
@@ -303,26 +298,25 @@ class hackRequests(object):
         if post:
             method = "POST"
             if isinstance(post, str):
+                # try:
+                #     post = extract_dict(post, sep="&")
+                # except:
+                #     pass
+                pass
+            elif isinstance(post,dict):
                 try:
-                    post = extract_dict(post, sep="&")
+                    post = parse.urlencode(post)
                 except:
                     pass
-            try:
-                post = parse.urlencode(post)
-            except:
-                pass
-            if "Content-Type" not in headers:
-                tmp_headers["Content-Type"] = kwargs.get(
-                    "Content-type", "application/json")
-            if 'Accept' not in headers:
-                tmp_headers["Accept"] = tmp_headers.get("Accept", "*/*")
-        if 'Accept-Encoding' not in headers:
-            tmp_headers['Accept-Encoding'] = tmp_headers.get("Accept-Encoding", "gzip, deflate")
-        if 'Connection' not in headers:
-            tmp_headers['Connection'] = 'close'
-        if 'User-Agent' not in headers:
-            tmp_headers['User-Agent'] = tmp_headers['User-Agent'] if tmp_headers.get(
-                'User-Agent') else 'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.71 Safari/537.36'
+            else:
+                raise Exception("post must be str or dict")
+            tmp_headers["Content-Type"] = kwargs.get(
+                "Content-type", "application/x-www-form-urlencoded")
+            tmp_headers["Accept"] = tmp_headers.get("Accept", "*/*")
+        tmp_headers['Accept-Encoding'] = tmp_headers.get("Accept-Encoding", "gzip, deflate")
+        tmp_headers['Connection'] = 'close'
+        tmp_headers['User-Agent'] = tmp_headers['User-Agent'] if tmp_headers.get(
+            'User-Agent') else 'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.71 Safari/537.36'
 
         try:
             conn.request(method, path, post, tmp_headers)
@@ -387,7 +381,7 @@ class response(object):
             self.cookies = {}
 
         self.headers = _header_dict
-        self.header = str(self.rep.msg)  # response header
+        self.header = self.rep.msg  # response header
         self.log = log
         charset = self.rep.msg.get('content-type', 'utf-8')
         try:

--- a/HackRequests/HackRequests.py
+++ b/HackRequests/HackRequests.py
@@ -116,7 +116,7 @@ class hackRequests(object):
         else:
             self.httpcon = conpool
 
-    def _get_urlinfo(self, url, realhost: str):
+    def _get_urlinfo(self, url, params: dict,realhost: str):
         p = parse.urlparse(url)
         scheme = p.scheme.lower()
         if scheme != "http" and scheme != "https":
@@ -125,11 +125,17 @@ class hackRequests(object):
         port = 80 if scheme == "http" else 443
         if ":" in hostname:
             hostname, port = hostname.split(":")
-        path = ""
-        if p.path:
+        query = parse.urlencode(params)
+        if p.path == "":
+            path = "/"
+        else:
             path = p.path
-            if p.query:
-                path = path + "?" + p.query
+        if p.query:
+            path = path + "?" + p.query
+            if query:
+                path = path + "&" + query
+        elif query:
+            path = path + "?" + query
         if realhost:
             if ":" not in realhost:
                 realhost = realhost + ":80"
@@ -242,7 +248,7 @@ class hackRequests(object):
         log["response"] = "HTTP/%.1f %d %s" % (
             rep.version * 0.1, rep.status,
             rep.reason) + '\r\n' + str(rep.msg)
-        if port == 80 or port == 443:
+        if port == 80 or port == 
             _url = "{scheme}://{host}{path}".format(scheme=scheme, host=host, path=path)
         else:
             _url = "{scheme}://{host}{path}".format(scheme=scheme, host=host + ":" + port, path=path)
@@ -263,7 +269,7 @@ class hackRequests(object):
 
         proxy = kwargs.get('proxy', None)
         headers = kwargs.get('headers', {})
-
+        params = kwargs.get("params", {})
         # real host:ip
         real_host = kwargs.get("real_host", None)
 
@@ -286,7 +292,7 @@ class hackRequests(object):
         if "Content-Length" in headers:
             del headers["Content-Length"]
 
-        urlinfo = scheme, host, port, path = self._get_urlinfo(url, real_host)
+        urlinfo = scheme, host, port, path = self._get_urlinfo(url, params,real_host)
         log = {}
         try:
             conn = self.httpcon.get_con(urlinfo, proxy=proxy)

--- a/HackRequests/HackRequests.py
+++ b/HackRequests/HackRequests.py
@@ -15,6 +15,8 @@ import zlib
 from http import client
 from urllib import parse
 
+from pytest import param
+
 
 class HackError(Exception):
     def __init__(self, content):
@@ -252,13 +254,12 @@ class hackRequests(object):
             _url = "{scheme}://{host}{path}".format(scheme=scheme, host=host, path=path)
         else:
             _url = "{scheme}://{host}{path}".format(scheme=scheme, host=host + ":" + port, path=path)
-        
+
         redirect = rep.msg.get('location', None)  # handle 301/302
         if redirect and location:
             if not redirect.startswith('http'):
                 redirect = parse.urljoin(_url, redirect)
             return self.http(redirect, post=None, method=method, headers=headers, location=True, locationcount=1)
-
         return response(rep, _url, log, )
 
     def http(self, url, **kwargs):
@@ -293,6 +294,7 @@ class hackRequests(object):
             del headers["Content-Length"]
 
         urlinfo = scheme, host, port, path = self._get_urlinfo(url, params,real_host)
+
         log = {}
         try:
             conn = self.httpcon.get_con(urlinfo, proxy=proxy)
@@ -313,9 +315,12 @@ class hackRequests(object):
                     post = parse.urlencode(post)
                 except:
                     pass
+            else:
+                raise Exception("post must be str or dict")
             if "Content-Type" not in headers:
                 tmp_headers["Content-Type"] = kwargs.get(
-                    "Content-type", "application/json")
+                    "Content-type", "application/x-www-form-urlencoded")
+
             if 'Accept' not in headers:
                 tmp_headers["Accept"] = tmp_headers.get("Accept", "*/*")
         if 'Accept-Encoding' not in headers:

--- a/HackRequests/HackRequests.py
+++ b/HackRequests/HackRequests.py
@@ -15,8 +15,6 @@ import zlib
 from http import client
 from urllib import parse
 
-from pytest import param
-
 
 class HackError(Exception):
     def __init__(self, content):


### PR DESCRIPTION
为http() 增加了 params 参数，支持以 dict 形式传入query string，用起来像 requests 一样

```python
import HackRequests as hack
url = "http://127.0.0.1"
params = {"id":"1"}
resp = hack.http(url=url,params=params)
```

```python
threadpool = hack.threadpool(threadnum=3,callback=callback)
params = {"id":"1"}
for i in range(10):
    threadpool.http(url=url,params=params)
```
