### PR TITLE
魔改增加功能，便于盲注

### DIFF
--- a/HackRequests/HackRequests.py
+++ b/HackRequests/HackRequests.py
@@ -248,7 +248,7 @@ class hackRequests(object):
         log["response"] = "HTTP/%.1f %d %s" % (
             rep.version * 0.1, rep.status,
             rep.reason) + '\r\n' + str(rep.msg)
-        if port == 80 or port == 
+        if port == 80 or port == 443:
             _url = "{scheme}://{host}{path}".format(scheme=scheme, host=host, path=path)
         else:
             _url = "{scheme}://{host}{path}".format(scheme=scheme, host=host + ":" + port, path=path)

--- a/HackRequests/HackRequests.py
+++ b/HackRequests/HackRequests.py
@@ -15,8 +15,6 @@ import zlib
 from http import client
 from urllib import parse
 
-from pytest import param
-
 
 class HackError(Exception):
     def __init__(self, content):
@@ -157,6 +155,7 @@ class hackRequests(object):
         proxy = kwargs.get("proxy", None)
         real_host = kwargs.get("real_host", None)
         ssl = kwargs.get("ssl", False)
+        location = kwargs.get("location", True)
 
         scheme = 'http'
         port = 80
@@ -253,6 +252,13 @@ class hackRequests(object):
             _url = "{scheme}://{host}{path}".format(scheme=scheme, host=host, path=path)
         else:
             _url = "{scheme}://{host}{path}".format(scheme=scheme, host=host + ":" + port, path=path)
+        
+        redirect = rep.msg.get('location', None)  # handle 301/302
+        if redirect and location:
+            if not redirect.startswith('http'):
+                redirect = parse.urljoin(_url, redirect)
+            return self.http(redirect, post=None, method=method, headers=headers, location=True, locationcount=1)
+
         return response(rep, _url, log, )
 
     def http(self, url, **kwargs):
@@ -287,7 +293,6 @@ class hackRequests(object):
             del headers["Content-Length"]
 
         urlinfo = scheme, host, port, path = self._get_urlinfo(url, params,real_host)
-
         log = {}
         try:
             conn = self.httpcon.get_con(urlinfo, proxy=proxy)
@@ -308,15 +313,18 @@ class hackRequests(object):
                     post = parse.urlencode(post)
                 except:
                     pass
-            else:
-                raise Exception("post must be str or dict")
-            tmp_headers["Content-Type"] = kwargs.get(
-                "Content-type", "application/x-www-form-urlencoded")
-            tmp_headers["Accept"] = tmp_headers.get("Accept", "*/*")
-        tmp_headers['Accept-Encoding'] = tmp_headers.get("Accept-Encoding", "gzip, deflate")
-        tmp_headers['Connection'] = 'close'
-        tmp_headers['User-Agent'] = tmp_headers['User-Agent'] if tmp_headers.get(
-            'User-Agent') else 'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.71 Safari/537.36'
+            if "Content-Type" not in headers:
+                tmp_headers["Content-Type"] = kwargs.get(
+                    "Content-type", "application/json")
+            if 'Accept' not in headers:
+                tmp_headers["Accept"] = tmp_headers.get("Accept", "*/*")
+        if 'Accept-Encoding' not in headers:
+            tmp_headers['Accept-Encoding'] = tmp_headers.get("Accept-Encoding", "gzip, deflate")
+        if 'Connection' not in headers:
+            tmp_headers['Connection'] = 'close'
+        if 'User-Agent' not in headers:
+            tmp_headers['User-Agent'] = tmp_headers['User-Agent'] if tmp_headers.get(
+                'User-Agent') else 'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.71 Safari/537.36'
 
         try:
             conn.request(method, path, post, tmp_headers)
@@ -381,7 +389,7 @@ class response(object):
             self.cookies = {}
 
         self.headers = _header_dict
-        self.header = self.rep.msg  # response header
+        self.header = str(self.rep.msg)  # response header
         self.log = log
         charset = self.rep.msg.get('content-type', 'utf-8')
         try:

--- a/HackRequests/HackRequests.py
+++ b/HackRequests/HackRequests.py
@@ -15,6 +15,8 @@ import zlib
 from http import client
 from urllib import parse
 
+from pytest import param
+
 
 class HackError(Exception):
     def __init__(self, content):
@@ -155,7 +157,6 @@ class hackRequests(object):
         proxy = kwargs.get("proxy", None)
         real_host = kwargs.get("real_host", None)
         ssl = kwargs.get("ssl", False)
-        location = kwargs.get("location", True)
 
         scheme = 'http'
         port = 80
@@ -252,13 +253,6 @@ class hackRequests(object):
             _url = "{scheme}://{host}{path}".format(scheme=scheme, host=host, path=path)
         else:
             _url = "{scheme}://{host}{path}".format(scheme=scheme, host=host + ":" + port, path=path)
-        
-        redirect = rep.msg.get('location', None)  # handle 301/302
-        if redirect and location:
-            if not redirect.startswith('http'):
-                redirect = parse.urljoin(_url, redirect)
-            return self.http(redirect, post=None, method=method, headers=headers, location=True, locationcount=1)
-
         return response(rep, _url, log, )
 
     def http(self, url, **kwargs):
@@ -293,6 +287,7 @@ class hackRequests(object):
             del headers["Content-Length"]
 
         urlinfo = scheme, host, port, path = self._get_urlinfo(url, params,real_host)
+
         log = {}
         try:
             conn = self.httpcon.get_con(urlinfo, proxy=proxy)
@@ -303,26 +298,25 @@ class hackRequests(object):
         if post:
             method = "POST"
             if isinstance(post, str):
+                # try:
+                #     post = extract_dict(post, sep="&")
+                # except:
+                #     pass
+                pass
+            elif isinstance(post,dict):
                 try:
-                    post = extract_dict(post, sep="&")
+                    post = parse.urlencode(post)
                 except:
                     pass
-            try:
-                post = parse.urlencode(post)
-            except:
-                pass
-            if "Content-Type" not in headers:
-                tmp_headers["Content-Type"] = kwargs.get(
-                    "Content-type", "application/json")
-            if 'Accept' not in headers:
-                tmp_headers["Accept"] = tmp_headers.get("Accept", "*/*")
-        if 'Accept-Encoding' not in headers:
-            tmp_headers['Accept-Encoding'] = tmp_headers.get("Accept-Encoding", "gzip, deflate")
-        if 'Connection' not in headers:
-            tmp_headers['Connection'] = 'close'
-        if 'User-Agent' not in headers:
-            tmp_headers['User-Agent'] = tmp_headers['User-Agent'] if tmp_headers.get(
-                'User-Agent') else 'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.71 Safari/537.36'
+            else:
+                raise Exception("post must be str or dict")
+            tmp_headers["Content-Type"] = kwargs.get(
+                "Content-type", "application/x-www-form-urlencoded")
+            tmp_headers["Accept"] = tmp_headers.get("Accept", "*/*")
+        tmp_headers['Accept-Encoding'] = tmp_headers.get("Accept-Encoding", "gzip, deflate")
+        tmp_headers['Connection'] = 'close'
+        tmp_headers['User-Agent'] = tmp_headers['User-Agent'] if tmp_headers.get(
+            'User-Agent') else 'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.71 Safari/537.36'
 
         try:
             conn.request(method, path, post, tmp_headers)
@@ -387,7 +381,7 @@ class response(object):
             self.cookies = {}
 
         self.headers = _header_dict
-        self.header = str(self.rep.msg)  # response header
+        self.header = self.rep.msg  # response header
         self.log = log
         charset = self.rep.msg.get('content-type', 'utf-8')
         try:

--- a/HackRequests/HackRequests.py
+++ b/HackRequests/HackRequests.py
@@ -116,7 +116,7 @@ class hackRequests(object):
         else:
             self.httpcon = conpool
 
-    def _get_urlinfo(self, url, realhost: str):
+    def _get_urlinfo(self, url, params: dict,realhost: str):
         p = parse.urlparse(url)
         scheme = p.scheme.lower()
         if scheme != "http" and scheme != "https":
@@ -125,11 +125,17 @@ class hackRequests(object):
         port = 80 if scheme == "http" else 443
         if ":" in hostname:
             hostname, port = hostname.split(":")
-        path = ""
-        if p.path:
+        query = parse.urlencode(params)
+        if p.path == "":
+            path = "/"
+        else:
             path = p.path
-            if p.query:
-                path = path + "?" + p.query
+        if p.query:
+            path = path + "?" + p.query
+            if query:
+                path = path + "&" + query
+        elif query:
+            path = path + "?" + query
         if realhost:
             if ":" not in realhost:
                 realhost = realhost + ":80"
@@ -242,7 +248,7 @@ class hackRequests(object):
         log["response"] = "HTTP/%.1f %d %s" % (
             rep.version * 0.1, rep.status,
             rep.reason) + '\r\n' + str(rep.msg)
-        if port == 80 or port == 443:
+        if port == 80 or port == 
             _url = "{scheme}://{host}{path}".format(scheme=scheme, host=host, path=path)
         else:
             _url = "{scheme}://{host}{path}".format(scheme=scheme, host=host + ":" + port, path=path)
@@ -263,7 +269,7 @@ class hackRequests(object):
 
         proxy = kwargs.get('proxy', None)
         headers = kwargs.get('headers', {})
-
+        params = kwargs.get("params", {})
         # real host:ip
         real_host = kwargs.get("real_host", None)
 
@@ -286,7 +292,7 @@ class hackRequests(object):
         if "Content-Length" in headers:
             del headers["Content-Length"]
 
-        urlinfo = scheme, host, port, path = self._get_urlinfo(url, real_host)
+        urlinfo = scheme, host, port, path = self._get_urlinfo(url, params,real_host)
         log = {}
         try:
             conn = self.httpcon.get_con(urlinfo, proxy=proxy)

--- a/HackRequests/HackRequests.py
+++ b/HackRequests/HackRequests.py
@@ -348,11 +348,7 @@ class hackRequests(object):
         if post:
             method = "POST"
             if isinstance(post, str):
-                # try:
-                #     post = extract_dict(post, sep="&")
-                # except:
-                #     pass
-                pass
+                post = encode_invalid_chars(post)
             elif isinstance(post,dict):
                 try:
                     post = parse.urlencode(post)

--- a/HackRequests/HackRequests.py
+++ b/HackRequests/HackRequests.py
@@ -15,6 +15,8 @@ import zlib
 from http import client
 from urllib import parse
 
+from pytest import param
+
 
 class HackError(Exception):
     def __init__(self, content):
@@ -252,13 +254,12 @@ class hackRequests(object):
             _url = "{scheme}://{host}{path}".format(scheme=scheme, host=host, path=path)
         else:
             _url = "{scheme}://{host}{path}".format(scheme=scheme, host=host + ":" + port, path=path)
-        
+
         redirect = rep.msg.get('location', None)  # handle 301/302
         if redirect and location:
             if not redirect.startswith('http'):
                 redirect = parse.urljoin(_url, redirect)
             return self.http(redirect, post=None, method=method, headers=headers, location=True, locationcount=1)
-
         return response(rep, _url, log, )
 
     def http(self, url, **kwargs):
@@ -293,6 +294,7 @@ class hackRequests(object):
             del headers["Content-Length"]
 
         urlinfo = scheme, host, port, path = self._get_urlinfo(url, params,real_host)
+
         log = {}
         try:
             conn = self.httpcon.get_con(urlinfo, proxy=proxy)
@@ -313,9 +315,12 @@ class hackRequests(object):
                     post = parse.urlencode(post)
                 except:
                     pass
+            else:
+                raise Exception("post must be str or dict")
             if "Content-Type" not in headers:
                 tmp_headers["Content-Type"] = kwargs.get(
-                    "Content-type", "application/json")
+                    "Content-type", "application/x-www-form-urlencoded")
+
             if 'Accept' not in headers:
                 tmp_headers["Accept"] = tmp_headers.get("Accept", "*/*")
         if 'Accept-Encoding' not in headers:

--- a/HackRequests/HackRequests.py
+++ b/HackRequests/HackRequests.py
@@ -15,8 +15,6 @@ import zlib
 from http import client
 from urllib import parse
 
-from pytest import param
-
 
 class HackError(Exception):
     def __init__(self, content):

--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
+# 魔改增加功能：
+
+1. 为 `hackRequests.http()` / `http()` 增加了个 `params` 参数，支持传入 dict 形式的 query string（像 requests 一样）
+2. 为  `hackRequests.http()` / `http()` 增加了个 `timeout` 参数 ，这样写时间盲注之类的脚本的时候会方便一点
+3. 增加了个 `encode_invalid_chars()` 函数，这样 url 当中的非法字符就会被 urlencode 
+4. 给 `response` 类增加了一个 `elapsed`  ，通过调用 `resp.elapsed.total_seconds()` 能获得一次请求所用的时间，主要也是为了写盲注之类的脚本方便
+
 # hack-requests
+
 HackRequests 是基于`Python3.x`的一个给黑客们使用的http底层网络库。如果你需要一个不那么臃肿而且像requests一样优雅的设计，并且提供底层请求包/返回包原文来方便你进行下一步分析，如果你使用Burp Suite，可以将原始报文直接复制重放，对于大量的HTTP请求，hack-requests线程池也能帮你实现最快速的响应。
 
 - 像requests一样好用的设计
@@ -244,5 +252,4 @@ threadpool.run()
 | httpraw() | 见[说明文档]-[快速使用] | 将HTTP请求后加入现成队列，准备执行 |
 | stop()    |                         | 停止线程池                         |
 | run()     |                         | 启动线程池                         |
-
 


### PR DESCRIPTION
# 魔改增加功能：

1. 为 `hackRequests.http()` / `http()` 增加了个 `params` 参数，支持传入 dict 形式的 query string（像 requests 一样）
2. 为  `hackRequests.http()` / `http()` 增加了个 `timeout` 参数 ，这样写时间盲注之类的脚本的时候会方便一点
3. 增加了个 `encode_invalid_chars()` 函数，这样 url 当中的非法字符就会被 urlencode 
4. 给 `response` 类增加了一个 `elapsed`  ，通过调用 `resp.elapsed.total_seconds()` 能获得一次请求所用的时间，主要也是为了写盲注之类的脚本方便